### PR TITLE
Add async write with pause to TwinCATRx client

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Currently it does not support the following features:
     client.Observe<double[]>(".ArrLReal").Subscribe(data => Console.WriteLine(data));
 
     // Ensure the client is initialized before reading or writing
-    client.InitializeComplete().Subscribe(() =>
+    client.InitializeComplete.Subscribe(() =>
     {
         // Read tags of a simple type
         client.Read(".AString");
@@ -94,5 +94,15 @@ Currently it does not support the following features:
             
             // Values are written from the structure to the PLC upon return.
         });
+
+        data.WriteValuesAsync(ht =>
+        {
+            // write values to structure
+            ht.Value("AInt", (short)(tag + 10));
+            ht.Value("AString", $"Int Value {tag + 10}");
+            
+            // Values are written from the structure to the PLC upon return, 
+            // future usage of WriteValuesAsync will be delayed by the timespan delared with each call.
+        }, TimeSpan.FromMilliseconds(300))
     });
 ```

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Currently it does not support the following features:
 
     // Create structure to store data
     var tag1 = client.CreateStruct(".Tag1", true);
-    tag1.StructureReady().Subscribe(data =>
+    tag1.StructureReady().Subscribe(async data =>
     {
         // read from structure as stream
         data.Observe<bool>("ABool").Subscribe(value => Console.WriteLine(value));
@@ -95,7 +95,7 @@ Currently it does not support the following features:
             // Values are written from the structure to the PLC upon return.
         });
 
-        data.WriteValuesAsync(ht =>
+        _ = _await data.WriteValuesAsync(ht =>
         {
             // write values to structure
             ht.Value("AInt", (short)(tag + 10));

--- a/Version.json
+++ b/Version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "1.6.3",
+    "version": "1.6.4",
     "publicReleaseRefSpec": [
         "^refs/heads/master$",
         "^refs/heads/main$"

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.11.31" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.7.115" />
     <PackageReference Include="Nuke.Common" Version="9.0.4" />
     <PackageReference Include="CP.Nuke.BuildTools" Version="1.0.94" />

--- a/src/TwinCATRx.Core/DirectoryInfoGetFilesWhere.cs
+++ b/src/TwinCATRx.Core/DirectoryInfoGetFilesWhere.cs
@@ -72,7 +72,7 @@ public static class DirectoryInfoGetFilesWhere
     ///     </code>
     /// </example>
     public static FileInfo[] GetFilesWhere(this DirectoryInfo @this, Func<FileInfo, bool> predicate) =>
-        Directory.EnumerateFiles(@this?.FullName!).Select(x => new FileInfo(x)).Where(predicate).ToArray();
+        [.. Directory.EnumerateFiles(@this?.FullName!).Select(x => new FileInfo(x)).Where(predicate)];
 
     /// <summary>
     /// Returns an enumerable collection of file names that match a search pattern in a specified @this.
@@ -126,7 +126,7 @@ public static class DirectoryInfoGetFilesWhere
     /// </code>
     /// </example>
     public static FileInfo[] GetFilesWhere(this DirectoryInfo @this, string searchPattern, Func<FileInfo, bool> predicate) =>
-        Directory.EnumerateFiles(@this?.FullName!, searchPattern).Select(x => new FileInfo(x)).Where(predicate).ToArray();
+        [.. Directory.EnumerateFiles(@this?.FullName!, searchPattern).Select(x => new FileInfo(x)).Where(predicate)];
 
     /// <summary>
     /// Returns an enumerable collection of file names that match a search pattern in a specified @this, and optionally searches subdirectories.
@@ -184,7 +184,7 @@ public static class DirectoryInfoGetFilesWhere
     /// </code>
     /// </example>
     public static FileInfo[] GetFilesWhere(this DirectoryInfo @this, string searchPattern, SearchOption searchOption, Func<FileInfo, bool> predicate) =>
-        Directory.EnumerateFiles(@this?.FullName!, searchPattern, searchOption).Select(x => new FileInfo(x)).Where(predicate).ToArray();
+        [.. Directory.EnumerateFiles(@this?.FullName!, searchPattern, searchOption).Select(x => new FileInfo(x)).Where(predicate)];
 
     /// <summary>
     /// Returns an enumerable collection of file names that match a search pattern in a specified @this.
@@ -244,7 +244,7 @@ public static class DirectoryInfoGetFilesWhere
             throw new ArgumentNullException(nameof(@this));
         }
 
-        return searchPatterns.SelectMany(@this.GetFiles).Distinct().Where(predicate).ToArray();
+        return [.. searchPatterns.SelectMany(@this.GetFiles).Distinct().Where(predicate)];
     }
 
     /// <summary>
@@ -303,5 +303,5 @@ public static class DirectoryInfoGetFilesWhere
     /// </code>
     /// </example>
     public static FileInfo[] GetFilesWhere(this DirectoryInfo @this, string[] searchPatterns, SearchOption searchOption, Func<FileInfo, bool> predicate) =>
-        searchPatterns.SelectMany(x => @this.GetFiles(x, searchOption)).Distinct().Where(predicate).ToArray();
+        [.. searchPatterns.SelectMany(x => @this.GetFiles(x, searchOption)).Distinct().Where(predicate)];
 }

--- a/src/TwinCATRx/IRxTcAdsClient.cs
+++ b/src/TwinCATRx/IRxTcAdsClient.cs
@@ -74,6 +74,14 @@ public interface IRxTcAdsClient : ICancelable
     bool IsPaused { get; }
 
     /// <summary>
+    /// Gets the is paused observable.
+    /// </summary>
+    /// <value>
+    /// The is paused observable.
+    /// </value>
+    public IObservable<bool> IsPausedObservable { get; }
+
+    /// <summary>
     /// Pauses the specified time.
     /// </summary>
     /// <param name="time">The time.</param>

--- a/src/TwinCATRx/IRxTcAdsClient.cs
+++ b/src/TwinCATRx/IRxTcAdsClient.cs
@@ -66,6 +66,20 @@ public interface IRxTcAdsClient : ICancelable
     IDictionary<string, (uint? Handle, int ArrayLength)> WriteHandleInfo { get; }
 
     /// <summary>
+    /// Gets a value indicating whether this instance is paused within WriteValuesAsync.
+    /// </summary>
+    /// <value>
+    ///   <c>true</c> if this instance is paused; otherwise, <c>false</c>.
+    /// </value>
+    bool IsPaused { get; }
+
+    /// <summary>
+    /// Pauses the specified time.
+    /// </summary>
+    /// <param name="time">The time.</param>
+    void Pause(TimeSpan time);
+
+    /// <summary>
     /// Connects the specified settings.
     /// </summary>
     /// <param name="settings">The settings.</param>

--- a/src/TwinCATRx/IRxTcAdsClient.cs
+++ b/src/TwinCATRx/IRxTcAdsClient.cs
@@ -79,7 +79,7 @@ public interface IRxTcAdsClient : ICancelable
     /// <value>
     /// The is paused observable.
     /// </value>
-    public IObservable<bool> IsPausedObservable { get; }
+    IObservable<bool> IsPausedObservable { get; }
 
     /// <summary>
     /// Pauses the specified time.

--- a/src/TwinCATRx/RxTcAdsClient.cs
+++ b/src/TwinCATRx/RxTcAdsClient.cs
@@ -209,7 +209,7 @@ public partial class RxTcAdsClient : IRxTcAdsClient
     /// <param name="time">The time.</param>
     public void Pause(TimeSpan time)
     {
-        if (_cleanup?.IsDisposed == true)
+        if (_cleanup == null || _cleanup.IsDisposed)
         {
             _errorReceived.OnNext(new Exception("RxTcAdsClient has been Disposed"));
             return;

--- a/src/TwinCATRx/TwinCATRx.csproj
+++ b/src/TwinCATRx/TwinCATRx.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HashTableRx" Version="1.3.0" />
+    <PackageReference Include="HashTableRx" Version="1.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TwinCATRx/TwinCatRxExtensions.cs
+++ b/src/TwinCATRx/TwinCatRxExtensions.cs
@@ -79,7 +79,7 @@ public static class TwinCatRxExtensions
             using (var htClone = @this.CreateClone())
             {
                 setValues(htClone);
-                var structure = htClone.GetStucture();
+                var structure = htClone.GetStructure();
                 if (structure == null)
                 {
                     return false;
@@ -137,7 +137,7 @@ public static class TwinCatRxExtensions
             using (var htClone = @this.CreateClone())
             {
                 setValues(htClone);
-                var structure = htClone.GetStucture();
+                var structure = htClone.GetStructure();
                 if (structure == null)
                 {
                     return false;
@@ -184,6 +184,6 @@ public static class TwinCatRxExtensions
             throw new ArgumentNullException(nameof(@this));
         }
 
-        return new(@this!.UseUpperCase) { [true] = @this.GetStucture() };
+        return new(@this!.UseUpperCase) { [true] = @this.GetStructure() };
     }
 }

--- a/src/TwinCATRx/TwinCatRxExtensions.cs
+++ b/src/TwinCATRx/TwinCatRxExtensions.cs
@@ -86,9 +86,8 @@ public static class TwinCatRxExtensions
                 }
 
                 plc.Write(variable, structure);
+                return true;
             }
-
-            return true;
         }
 
         return false;
@@ -139,6 +138,7 @@ public static class TwinCatRxExtensions
                 }
 
                 plc.Write(variable, structure);
+                return true;
             }
         }
 


### PR DESCRIPTION
Introduces WriteValuesAsync to allow delayed asynchronous writes to PLC structures, with a pause mechanism to prevent overlapping writes. Adds IsPaused and Pause methods to IRxTcAdsClient and RxTcAdsClient, updates documentation, and improves extension method safety. Also updates dependencies and documentation, and bumps version to 1.6.4.