### PR TITLE
Use ReplaySubject for service status

### DIFF
--- a/src/TwinCATRx/RxTcAdsClient.cs
+++ b/src/TwinCATRx/RxTcAdsClient.cs
@@ -29,7 +29,7 @@ public partial class RxTcAdsClient : IRxTcAdsClient
     private readonly Subject<Exception> _errorReceived = new();
     private readonly Subject<string?> _onWriteSubject = new();
     private readonly Subject<(uint? handle, Type type, int length, string? id)> _readPLC = new();
-    private readonly Subject<ServiceStatus> _serviceStatus = new();
+    private readonly ReplaySubject<ServiceStatus> _serviceStatus = new(1);
     private readonly Subject<(uint? handle, object value, int length, string? id)> _writePLC = new();
     private readonly ReplaySubject<Unit> _initCompleteSubject = new(1);
     private readonly ReplaySubject<bool> _isPausedSubject = new(1);


### PR DESCRIPTION
Replace Subject<ServiceStatus> with ReplaySubject<ServiceStatus>(1) so the last emitted service status is cached and immediately replayed to new subscribers. This aligns the service status behavior with other ReplaySubjects in the class (e.g. _initCompleteSubject, _isPausedSubject) and prevents subscribers from missing the latest status.