### PR TITLE
Migrate to MinVer versioning with 2.2 floor

### DIFF
--- a/.github/workflows/BuildDeploy.yml
+++ b/.github/workflows/BuildDeploy.yml
@@ -38,7 +38,7 @@ env:
   configuration: Release
   solutionFile: TwinCATRx.slnx
   solutionFolder: src
-  minMajorMinorVersion: '5.1'
+  minMajorMinorVersion: '2.2'
 
 jobs:
   release:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,6 +39,16 @@
     <Features>$(Features);runtime-async=on</Features>
   </PropertyGroup>
 
+  <!-- MinVer (versioning) — replaces Nerdbank.GitVersioning. Floor at 2.2
+       so untagged builds produce 2.2.x-alpha.0.<height> until a v2.2.x
+       (or later) tag is reachable. -->
+  <PropertyGroup>
+    <MinVerAutoIncrement>minor</MinVerAutoIncrement>
+    <MinVerDefaultPreReleaseIdentifiers>alpha.0</MinVerDefaultPreReleaseIdentifiers>
+    <MinVerTagPrefix>v</MinVerTagPrefix>
+    <MinVerMinimumMajorMinor>2.2</MinVerMinimumMajorMinor>
+  </PropertyGroup>
+
   <ItemGroup Condition="'$(IsTestProject)' != 'true'">
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <PackageVersion Include="HashTableRx" Version="3.2.0" />
     <PackageVersion Include="HashTableRx.Reactive" Version="3.2.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
     <PackageVersion Include="Mono.Cecil" Version="0.11.6" />


### PR DESCRIPTION
Switch from Nerdbank.GitVersioning to MinVer for version management. Configure MinVer to use 2.2 as the minimum version floor, ensuring untagged builds produce 2.2.x-alpha.0.<height> versions. Downgrade Microsoft.CodeAnalysis.CSharp to 5.0.0 for compatibility.